### PR TITLE
initialize Colorix with dark_mode setting from context

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ impl Default for Colorix {
 impl Colorix {
     pub fn init(ctx: &mut egui::Context, theme: [ColorPreset; 12]) -> Self {
         let mut colorix = Colorix { theme, ..Default::default() };
+        colorix.scales.dark_mode = ctx.style().visuals.dark_mode;
         colorix.get_theme_index();
         colorix.update_colors(ctx);
         colorix


### PR DESCRIPTION
Hi, nice library! I've tried using it, but found that it doesn't correctly initialize in case where I want it to start in dark mode first.
I found that Colorix doesn't initialize scale with current dark_mode setting taken into account, so I have fixed that.
I hope this change will be welcome :)