### PR TITLE
Improve `ui_combo_12` ui for custom color presets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,27 +195,32 @@ impl Colorix {
         ui.vertical(|ui| {
             for (i, label) in LABELS.iter().enumerate() {
                 ui.horizontal(|ui| {
+                    let tokens = [
+                        self.tokens.app_background,
+                        self.tokens.subtle_background,
+                        self.tokens.ui_element_background,
+                        self.tokens.hovered_ui_element_background,
+                        self.tokens.active_ui_element_background,
+                        self.tokens.subtle_borders_and_separators,
+                        self.tokens.ui_element_border_and_focus_rings,
+                        self.tokens.hovered_ui_element_border,
+                        self.tokens.solid_backgrounds,
+                        self.tokens.hovered_solid_backgrounds,
+                        self.tokens.low_contrast_text,
+                        self.tokens.high_contrast_text,
+                    ];
+                    let color_edit_size = egui::vec2(40.0, 18.0);
                     if let Some(ColorPreset::Custom(rgb)) = self.theme.get_mut(i) {
                         let re = ui.color_edit_button_srgb(rgb);
                         if re.changed() {
                             self.update_color(ctx, i);
                         }
-                        let tokens = [
-                            self.tokens.app_background,
-                            self.tokens.subtle_background,
-                            self.tokens.ui_element_background,
-                            self.tokens.hovered_ui_element_background,
-                            self.tokens.active_ui_element_background,
-                            self.tokens.subtle_borders_and_separators,
-                            self.tokens.ui_element_border_and_focus_rings,
-                            self.tokens.hovered_ui_element_border,
-                            self.tokens.solid_backgrounds,
-                            self.tokens.hovered_solid_backgrounds,
-                            self.tokens.low_contrast_text,
-                            self.tokens.high_contrast_text,
-                        ];
-                        egui::widgets::color_picker::show_color(ui, tokens[i], re.rect.size());
+                    } else {
+                        // Allocate a color edit button's worth of space for non-custom presets,
+                        // for alignment purposes.
+                        ui.add_space(color_edit_size.x + ui.style().spacing.item_spacing.x);
                     }
+                    egui::widgets::color_picker::show_color(ui, tokens[i], color_edit_size);
                     egui::ComboBox::from_label(*label)
                         .selected_text(self.theme[i].label())
                         .show_ui(ui, |ui| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,22 +194,45 @@ impl Colorix {
         ui.add_space(20.);
         ui.vertical(|ui| {
             for (i, label) in LABELS.iter().enumerate() {
-                egui::ComboBox::from_label(*label)
-                    .selected_text(format!("{:?}", self.theme[i]))
-                    .show_ui(ui, |ui| {
-                        for j in 0..dropdown_colors.len() {
-                            if ui
-                                .selectable_value(
-                                    &mut self.theme[i],
-                                    dropdown_colors[j],
-                                    DROPDOWN_TEXT[j],
-                                )
-                                .clicked()
-                            {
-                                self.update_color(ctx, i);
-                            };
+                ui.horizontal(|ui| {
+                    if let Some(ColorPreset::Custom(rgb)) = self.theme.get_mut(i) {
+                        let re = ui.color_edit_button_srgb(rgb);
+                        if re.changed() {
+                            self.update_color(ctx, i);
                         }
-                    });
+                        let tokens = [
+                            self.tokens.app_background,
+                            self.tokens.subtle_background,
+                            self.tokens.ui_element_background,
+                            self.tokens.hovered_ui_element_background,
+                            self.tokens.active_ui_element_background,
+                            self.tokens.subtle_borders_and_separators,
+                            self.tokens.ui_element_border_and_focus_rings,
+                            self.tokens.hovered_ui_element_border,
+                            self.tokens.solid_backgrounds,
+                            self.tokens.hovered_solid_backgrounds,
+                            self.tokens.low_contrast_text,
+                            self.tokens.high_contrast_text,
+                        ];
+                        egui::widgets::color_picker::show_color(ui, tokens[i], re.rect.size());
+                    }
+                    egui::ComboBox::from_label(*label)
+                        .selected_text(self.theme[i].label())
+                        .show_ui(ui, |ui| {
+                            for j in 0..dropdown_colors.len() {
+                                if ui
+                                    .selectable_value(
+                                        &mut self.theme[i],
+                                        dropdown_colors[j],
+                                        DROPDOWN_TEXT[j],
+                                    )
+                                    .clicked()
+                                {
+                                    self.update_color(ctx, i);
+                                };
+                            }
+                        });
+                });
             }
         });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,6 @@ pub struct Colorix {
     pub(crate) theme: [ColorPreset; 12],
     theme_index: usize,
     pub(crate) scales: Scales,
-    show_rgb: bool,
 }
 
 impl Colorix {
@@ -194,7 +193,6 @@ impl Colorix {
             ColorPreset::Orange,
             ColorPreset::Custom(self.scales.custom()),
         ];
-        ui.checkbox(&mut self.show_rgb, "Show rgb labels for custom");
         ui.vertical(|ui| {
             for (i, label) in LABELS.iter().enumerate() {
                 ui.horizontal(|ui| {
@@ -227,11 +225,10 @@ impl Colorix {
                             }
                         });
                 });
-                if self.show_rgb {
-                    if let Some(ColorPreset::Custom([r, g, b])) = self.theme.get(i) {
-                        ui.label(format!("{r}, {g}, {b}"));
-                    }
-                }
+            }
+            ui.add_space(8.0);
+            if ui.button("Copy theme to clipboard").clicked() {
+                ui.output_mut(|out| out.copied_text = format!("{:#?}", self.theme));
             }
         });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,10 +89,11 @@ impl Colorix {
                 .on_hover_text("Switch to light mode")
                 .clicked()
             {
-                let mut style = egui::Style::default();
-                style.visuals.dark_mode = false;
                 self.scales.dark_mode = false;
-                ctx.set_style(style);
+                ctx.set_visuals(egui::Visuals {
+                    dark_mode: false,
+                    ..Default::default()
+                });
                 self.update_colors(ctx);
             }
         } else {
@@ -105,10 +106,11 @@ impl Colorix {
                 .on_hover_text("Switch to dark mode")
                 .clicked()
             {
-                let mut style = egui::Style::default();
-                style.visuals.dark_mode = true;
                 self.scales.dark_mode = true;
-                ctx.set_style(style);
+                ctx.set_visuals(egui::Visuals {
+                    dark_mode: true,
+                    ..Default::default()
+                });
                 self.update_colors(ctx);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub struct Colorix {
     pub(crate) theme: [ColorPreset; 12],
     theme_index: usize,
     pub(crate) scales: Scales,
+    show_rgb: bool,
 }
 
 impl Colorix {
@@ -191,7 +192,7 @@ impl Colorix {
             ColorPreset::Orange,
             ColorPreset::Custom(self.scales.custom()),
         ];
-        ui.add_space(20.);
+        ui.checkbox(&mut self.show_rgb, "Show rgb labels for custom");
         ui.vertical(|ui| {
             for (i, label) in LABELS.iter().enumerate() {
                 ui.horizontal(|ui| {
@@ -238,6 +239,11 @@ impl Colorix {
                             }
                         });
                 });
+                if self.show_rgb {
+                    if let Some(ColorPreset::Custom([r, g, b])) = self.theme.get(i) {
+                        ui.label(format!("{r}, {g}, {b}"));
+                    }
+                }
             }
         });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,20 +198,6 @@ impl Colorix {
         ui.vertical(|ui| {
             for (i, label) in LABELS.iter().enumerate() {
                 ui.horizontal(|ui| {
-                    let tokens = [
-                        self.tokens.app_background,
-                        self.tokens.subtle_background,
-                        self.tokens.ui_element_background,
-                        self.tokens.hovered_ui_element_background,
-                        self.tokens.active_ui_element_background,
-                        self.tokens.subtle_borders_and_separators,
-                        self.tokens.ui_element_border_and_focus_rings,
-                        self.tokens.hovered_ui_element_border,
-                        self.tokens.solid_backgrounds,
-                        self.tokens.hovered_solid_backgrounds,
-                        self.tokens.low_contrast_text,
-                        self.tokens.high_contrast_text,
-                    ];
                     let color_edit_size = egui::vec2(40.0, 18.0);
                     if let Some(ColorPreset::Custom(rgb)) = self.theme.get_mut(i) {
                         let re = ui.color_edit_button_srgb(rgb);
@@ -223,7 +209,11 @@ impl Colorix {
                         // for alignment purposes.
                         ui.add_space(color_edit_size.x + ui.style().spacing.item_spacing.x);
                     }
-                    egui::widgets::color_picker::show_color(ui, tokens[i], color_edit_size);
+                    egui::widgets::color_picker::show_color(
+                        ui,
+                        self.tokens.get_token(i),
+                        color_edit_size,
+                    );
                     egui::ComboBox::from_label(*label)
                         .selected_text(self.theme[i].label())
                         .show_ui(ui, |ui| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub mod utils;
 
 use scales::Scales;
 use tokens::{ColorPreset, ColorTokens};
-use utils::{DROPDOWN_TEXT, LABELS, THEMES, THEME_NAMES};
+use utils::{LABELS, THEMES, THEME_NAMES};
 
 /// The Colorix type is the main entry to this crate.
 ///
@@ -225,13 +225,9 @@ impl Colorix {
                     egui::ComboBox::from_label(*label)
                         .selected_text(self.theme[i].label())
                         .show_ui(ui, |ui| {
-                            for j in 0..dropdown_colors.len() {
+                            for preset in dropdown_colors {
                                 if ui
-                                    .selectable_value(
-                                        &mut self.theme[i],
-                                        dropdown_colors[j],
-                                        DROPDOWN_TEXT[j],
-                                    )
+                                    .selectable_value(&mut self.theme[i], preset, preset.label())
                                     .clicked()
                                 {
                                     self.update_color(ctx, i);

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -232,4 +232,31 @@ impl ColorPreset {
             Self::Custom([r, g, b]) => [r, g, b],
         }
     }
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Gray => "Gray",
+            Self::EguiBlue => "EguiBlue",
+            Self::Tomato => "Tomato",
+            Self::Red => "Red",
+            Self::Ruby => "Ruby",
+            Self::Crimson => "Crimson",
+            Self::Pink => "Pink",
+            Self::Plum => "Plum",
+            Self::Purple => "Purple",
+            Self::Violet => "Violet",
+            Self::Iris => "Iris",
+            Self::Indigo => "Indigo",
+            Self::Blue => "Blue",
+            Self::Cyan => "Cyan",
+            Self::Teal => "Teal",
+            Self::Jade => "Jade",
+            Self::Green => "Green",
+            Self::Grass => "Grass",
+            Self::Brown => "Brown",
+            Self::Bronze => "Bronze",
+            Self::Gold => "Gold",
+            Self::Orange => "Orange",
+            Self::Custom(_) => "Custom",
+        }
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -115,12 +115,6 @@ pub(crate) const THEMES: [[ColorPreset; 12]; 7] = [
     OFFICE_GRAY,
 ];
 
-pub(crate) const DROPDOWN_TEXT: [&str; 23] = [
-    "Gray", "EguiBlue", "Tomato", "Red", "Ruby", "Crimson", "Pink", "Plum", "Purple", "Violet",
-    "Iris", "Indigo", "Blue", "Cyan", "Teal", "Jade", "Green", "Grass", "Brown", "Bronze", "Gold",
-    "Orange", "Custom",
-];
-
 pub(crate) const LABELS: [&str; 12] = [
     "app background",
     "subtle background",


### PR DESCRIPTION
Shows color swatches for both the preset color and the resulting token

![image](https://github.com/user-attachments/assets/028320eb-8623-4830-8e59-1b7f01ce8264)
