### PR TITLE
Add optional serde support for ThemeColor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,7 @@ version = "0.5.0"
 dependencies = [
  "egui",
  "palette",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ members = ["examples/hello_colors"]
 [dependencies]
 egui = { version = "0.30.0", default-features = false }
 palette = "0.7.6"
+serde = { version = "1", optional = true, default-features = false, features = ["derive"] }
+
+[features]
+serde = ["dep:serde"]
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -156,6 +156,7 @@ impl ColorTokens {
 /// my_theme[11] = ThemeColor::Custom([23, 45, 77]);
 /// ```
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ThemeColor {
     #[default]
     Gray,


### PR DESCRIPTION
This PR adds a crate feature that enables serializing and deserializing themes using serde.