### PR TITLE
Allow scoped application of themes

### DIFF
--- a/src/apply_to.rs
+++ b/src/apply_to.rs
@@ -1,5 +1,5 @@
-use crate::tokens::ColorTokens;
-use egui::Ui;
+use egui::{Ui, Visuals};
+use crate::Colorix;
 
 /// The `ApplyTo` enum is used to determine if a theme change should be applied
 /// globally, locally or not at all.
@@ -17,13 +17,25 @@ pub enum ApplyTo {
 }
 
 impl ApplyTo {
-    pub(crate) fn apply(self, ui: &mut Ui, tokens: &ColorTokens) {
+    pub(crate) fn apply(self, ui: &mut Ui, colorix: &Colorix) {
         match self {
             Self::Global => {
-                tokens.set_global_egui_visuals(ui.ctx());
+                colorix.apply_global(ui.ctx());
             }
             Self::Local => {
-                tokens.set_local_egui_visuals(ui);
+                colorix.apply_local(ui);
+            }
+            Self::Nothing => {}
+        }
+    }
+
+    pub(crate) fn set_visuals(self, ui: &mut Ui, visuals: Visuals) {
+        match self {
+            Self::Global => {
+                ui.ctx().set_visuals(visuals);
+            }
+            Self::Local => {
+                ui.style_mut().visuals = visuals;
             }
             Self::Nothing => {}
         }

--- a/src/apply_to.rs
+++ b/src/apply_to.rs
@@ -1,0 +1,25 @@
+use crate::tokens::ColorTokens;
+use egui::Ui;
+
+/// The `ApplyTo` enum is used to determine if a theme change should be applied
+/// globally, locally or not at all.
+#[derive(Debug, Copy, Clone)]
+pub enum ApplyTo {
+    Global,
+    Local,
+    Nothing,
+}
+
+impl ApplyTo {
+    pub(crate) fn apply(self, ui: &mut Ui, tokens: &ColorTokens) {
+        match self {
+            Self::Global => {
+                tokens.set_global_egui_visuals(ui.ctx());
+            }
+            Self::Local => {
+                tokens.set_local_egui_visuals(ui);
+            }
+            Self::Nothing => {}
+        }
+    }
+}

--- a/src/apply_to.rs
+++ b/src/apply_to.rs
@@ -5,8 +5,14 @@ use egui::Ui;
 /// globally, locally or not at all.
 #[derive(Debug, Copy, Clone)]
 pub enum ApplyTo {
+    /// Theme changes are applied to the global egui context.
     Global,
+    /// Theme changes are applied to the local widget tree only.
     Local,
+    /// No theme changes are applied.
+    ///
+    /// This is useful when theme is applied manually in a different part of
+    /// the interface.
     Nothing,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 //!
 
 pub(crate) mod apca;
+pub mod apply_to;
 pub(crate) mod scales;
 pub mod tokens;
 /// Some predefined themes
@@ -18,6 +19,8 @@ pub mod utils;
 use scales::Scales;
 use tokens::{ColorTokens, ThemeColor};
 use utils::{LABELS, THEMES, THEME_NAMES};
+
+pub use apply_to::ApplyTo;
 
 /// A set of colors that are used together to set a visual feel for the ui
 pub type Theme = [ThemeColor; 12];
@@ -42,6 +45,7 @@ pub type Theme = [ThemeColor; 12];
 ///     fn new(ctx: &Context) -> Self {
 ///         let yellow_theme = [ThemeColor::Custom([232, 210, 7]); 12];
 ///         let colorix = Colorix::init(ctx, yellow_theme);
+///         colorix.apply_global(ctx);
 ///         Self {
 ///             colorix,
 ///             ..Default::default()
@@ -58,16 +62,34 @@ pub struct Colorix {
 }
 
 impl Colorix {
+    /// Initialize the Colorix with the dark mode setting pulled from the Egui
+    /// context
     #[allow(clippy::must_use_candidate)]
     pub fn init(ctx: &egui::Context, theme: Theme) -> Self {
+        Self::init_with_dark_mode(theme, ctx.style().visuals.dark_mode)
+    }
+
+    /// Initialize the Colorix with a dark mode setting
+    #[allow(clippy::must_use_candidate)]
+    pub fn init_with_dark_mode(theme: Theme, is_dark_mode: bool) -> Self {
         let mut colorix = Self {
             theme,
             ..Default::default()
         };
-        colorix.scales.dark_mode = ctx.style().visuals.dark_mode;
+        colorix.scales.dark_mode = is_dark_mode;
         colorix.get_theme_index();
-        colorix.update_colors(ctx);
+        colorix.update_colors();
         colorix
+    }
+
+    /// Applies the theme to the global Egui context
+    pub fn apply_global(&self, ctx: &egui::Context) {
+        self.tokens.set_global_egui_visuals(ctx);
+    }
+
+    /// Applies the theme to the local widget tree only
+    pub fn apply_local(&self, ui: &mut egui::Ui) {
+        self.tokens.set_local_egui_visuals(ui);
     }
 
     fn get_theme_index(&mut self) {
@@ -76,26 +98,29 @@ impl Colorix {
         };
     }
 
-    pub fn set_dark(&mut self, ui: &mut egui::Ui) {
+    pub fn set_dark(&mut self, ui: &mut egui::Ui, apply_to: ApplyTo) {
         self.scales.dark_mode = true;
         ui.ctx().set_visuals(egui::Visuals {
             dark_mode: true,
             ..Default::default()
         });
-        self.update_colors(ui.ctx());
+        self.update_colors();
+        apply_to.apply(ui, &self.tokens);
     }
-    pub fn set_light(&mut self, ui: &mut egui::Ui) {
+
+    pub fn set_light(&mut self, ui: &mut egui::Ui, apply_to: ApplyTo) {
         self.scales.dark_mode = false;
         ui.ctx().set_visuals(egui::Visuals {
             dark_mode: false,
             ..Default::default()
         });
-        self.update_colors(ui.ctx());
+        self.update_colors();
+        apply_to.apply(ui, &self.tokens);
     }
 
     /// WARNING: don't use the `light_dark` buttons that Egui provides.
     /// That will override the theme from this crate.
-    pub fn light_dark_toggle_button(&mut self, ui: &mut egui::Ui) {
+    pub fn light_dark_toggle_button(&mut self, ui: &mut egui::Ui, apply_to: ApplyTo) {
         #![allow(clippy::collapsible_else_if)]
         if ui.ctx().style().visuals.dark_mode {
             self.scales.dark_mode = true;
@@ -113,7 +138,8 @@ impl Colorix {
                     dark_mode: false,
                     ..Default::default()
                 });
-                self.update_colors(ui.ctx());
+                self.update_colors();
+                apply_to.apply(ui, &self.tokens);
             }
         } else {
             if ui
@@ -130,7 +156,8 @@ impl Colorix {
                     dark_mode: true,
                     ..Default::default()
                 });
-                self.update_colors(ui.ctx());
+                self.update_colors();
+                apply_to.apply(ui, &self.tokens);
             }
         }
     }
@@ -154,6 +181,7 @@ impl Colorix {
         ui: &mut egui::Ui,
         custom_themes: Option<(Vec<&str>, Vec<Theme>)>,
         custom_only: bool,
+        apply_to: ApplyTo,
     ) {
         let combi_themes: Vec<Theme>;
         let combi_names: Vec<&str>;
@@ -180,14 +208,15 @@ impl Colorix {
                         .clicked()
                     {
                         self.theme_index = i;
-                        self.update_colors(ui.ctx());
+                        self.update_colors();
+                        apply_to.apply(ui, &self.tokens);
                     };
                 }
             });
     }
     /// A widget with 12 dropdown menus of the UI elements (`ColorTokens`) that can be set.
     /// Add copy: true to display a button to copy the theme in debug format
-    pub fn ui_combo_12(&mut self, ui: &mut egui::Ui, copy: bool) {
+    pub fn ui_combo_12(&mut self, ui: &mut egui::Ui, copy: bool, apply_to: ApplyTo) {
         let dropdown_colors: [ThemeColor; 23] = [
             ThemeColor::Gray,
             ThemeColor::EguiBlue,
@@ -220,7 +249,8 @@ impl Colorix {
                     if let Some(ThemeColor::Custom(rgb)) = self.theme.get_mut(i) {
                         let re = ui.color_edit_button_srgb(rgb);
                         if re.changed() {
-                            self.update_color(ui.ctx(), i);
+                            self.update_color(i);
+                            apply_to.apply(ui, &self.tokens);
                         }
                     } else {
                         // Allocate a color edit button's worth of space for non-custom presets,
@@ -240,7 +270,8 @@ impl Colorix {
                                     .selectable_value(&mut self.theme[i], preset, preset.label())
                                     .clicked()
                                 {
-                                    self.update_color(ui.ctx(), i);
+                                    self.update_color(i);
+                                    apply_to.apply(ui, &self.tokens);
                                 };
                             }
                         });
@@ -274,17 +305,15 @@ impl Colorix {
         }
     }
 
-    fn update_color(&mut self, ctx: &egui::Context, i: usize) {
+    fn update_color(&mut self, i: usize) {
         self.scales.process_color(self.theme[i]);
         self.tokens.update_schema(i, self.scales.scale[i]);
         self.tokens.color_on_accent();
-        self.tokens.set_egui_visuals(ctx);
     }
 
-    fn update_colors(&mut self, ctx: &egui::Context) {
+    fn update_colors(&mut self) {
         self.process_theme();
         self.tokens.color_on_accent();
-        self.tokens.set_egui_visuals(ctx);
     }
 
     /// NOTE: values are clamped for useability.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,9 @@ impl Colorix {
             self.theme_index = i;
         };
     }
-    
+
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)]
     pub fn is_dark(&self) -> bool {
         self.scales.dark_mode
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ impl Colorix {
 
     /// Applies the theme to the local widget tree only
     pub fn apply_local(&self, ui: &mut egui::Ui) {
-        self.tokens.set_local_egui_visuals(ui);
+        self.tokens.set_local_egui_visuals(ui, self.scales.dark_mode);
     }
 
     fn get_theme_index(&mut self) {
@@ -97,30 +97,34 @@ impl Colorix {
             self.theme_index = i;
         };
     }
+    
+    pub fn is_dark(&self) -> bool {
+        self.scales.dark_mode
+    }
 
     pub fn set_dark(&mut self, ui: &mut egui::Ui, apply_to: ApplyTo) {
         self.scales.dark_mode = true;
-        ui.ctx().set_visuals(egui::Visuals {
+        apply_to.set_visuals(ui, egui::Visuals {
             dark_mode: true,
             ..Default::default()
         });
         self.update_colors();
-        apply_to.apply(ui, &self.tokens);
+        apply_to.apply(ui, self);
     }
 
     pub fn set_light(&mut self, ui: &mut egui::Ui, apply_to: ApplyTo) {
         self.scales.dark_mode = false;
-        ui.ctx().set_visuals(egui::Visuals {
+        apply_to.set_visuals(ui, egui::Visuals {
             dark_mode: false,
             ..Default::default()
         });
         self.update_colors();
-        apply_to.apply(ui, &self.tokens);
+        apply_to.apply(ui, self);
     }
 
     /// WARNING: don't use the `light_dark` buttons that Egui provides.
     /// That will override the theme from this crate.
-    pub fn light_dark_toggle_button(&mut self, ui: &mut egui::Ui, apply_to: ApplyTo) {
+    pub fn light_dark_toggle_button(&mut self, ui: &mut egui::Ui) {
         #![allow(clippy::collapsible_else_if)]
         if ui.ctx().style().visuals.dark_mode {
             self.scales.dark_mode = true;
@@ -134,12 +138,12 @@ impl Colorix {
                 .clicked()
             {
                 self.scales.dark_mode = false;
-                ui.ctx().set_visuals(egui::Visuals {
+                ApplyTo::Global.set_visuals(ui, egui::Visuals {
                     dark_mode: false,
                     ..Default::default()
                 });
                 self.update_colors();
-                apply_to.apply(ui, &self.tokens);
+                ApplyTo::Global.apply(ui, self);
             }
         } else {
             if ui
@@ -152,12 +156,12 @@ impl Colorix {
                 .clicked()
             {
                 self.scales.dark_mode = true;
-                ui.ctx().set_visuals(egui::Visuals {
+                ApplyTo::Global.set_visuals(ui, egui::Visuals {
                     dark_mode: true,
                     ..Default::default()
                 });
                 self.update_colors();
-                apply_to.apply(ui, &self.tokens);
+                ApplyTo::Global.apply(ui, self);
             }
         }
     }
@@ -209,7 +213,7 @@ impl Colorix {
                     {
                         self.theme_index = i;
                         self.update_colors();
-                        apply_to.apply(ui, &self.tokens);
+                        apply_to.apply(ui, self);
                     };
                 }
             });
@@ -250,7 +254,7 @@ impl Colorix {
                         let re = ui.color_edit_button_srgb(rgb);
                         if re.changed() {
                             self.update_color(i);
-                            apply_to.apply(ui, &self.tokens);
+                            apply_to.apply(ui, self);
                         }
                     } else {
                         // Allocate a color edit button's worth of space for non-custom presets,
@@ -271,7 +275,7 @@ impl Colorix {
                                     .clicked()
                                 {
                                     self.update_color(i);
-                                    apply_to.apply(ui, &self.tokens);
+                                    apply_to.apply(ui, self);
                                 };
                             }
                         });

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -2,7 +2,7 @@ use crate::apca::estimate_lc;
 use egui::{
     self,
     style::{TextCursorStyle, WidgetVisuals},
-    Color32, Rounding, Stroke,
+    Color32, Rounding, Stroke, Style, Ui,
 };
 use palette::{LinSrgb, Srgb};
 
@@ -74,12 +74,28 @@ impl ColorTokens {
         }
     }
 
-    pub(crate) fn set_egui_visuals(&self, ctx: &egui::Context) {
+    pub(crate) fn set_global_egui_visuals(&self, ctx: &egui::Context) {
         if ctx.style().visuals.dark_mode {
             ctx.set_visuals_of(egui::Theme::Dark, egui::Visuals::dark());
         } else {
             ctx.set_visuals_of(egui::Theme::Light, egui::Visuals::light());
         }
+
+        ctx.style_mut(|style| { self.set_egui_style(style); });
+    }
+    pub(crate) fn set_local_egui_visuals(&self, ui: &mut Ui) {
+        let style = ui.style_mut();
+
+        if style.visuals.dark_mode {
+            style.visuals = egui::Visuals::dark();
+        } else {
+            style.visuals = egui::Visuals::light();
+        }
+
+        self.set_egui_style(style);
+    }
+
+    pub(crate) fn set_egui_style(&self, style: &mut Style) {
         let selection = egui::style::Selection {
             bg_fill: self.solid_backgrounds,
             stroke: Stroke::new(1.0, self.on_accent),
@@ -131,19 +147,17 @@ impl ColorTokens {
             },
         };
 
-        ctx.style_mut(|style| {
-            style.visuals.selection = selection;
-            style.visuals.widgets = widgets;
-            style.visuals.text_cursor = text_cursor;
-            style.visuals.extreme_bg_color = self.app_background; // e.g. TextEdit background
-            style.visuals.faint_bg_color = self.app_background; // striped grid is originally from_additive_luminance(5)
-            style.visuals.code_bg_color = self.ui_element_background;
-            style.visuals.window_fill = self.subtle_background;
-            style.visuals.window_stroke = Stroke::new(1.0, self.subtle_borders_and_separators);
-            style.visuals.panel_fill = self.subtle_background;
-            style.visuals.hyperlink_color = self.hovered_solid_backgrounds;
-            //style.visuals.override_text_color = Some(self.text_color());
-        });
+        style.visuals.selection = selection;
+        style.visuals.widgets = widgets;
+        style.visuals.text_cursor = text_cursor;
+        style.visuals.extreme_bg_color = self.app_background; // e.g. TextEdit background
+        style.visuals.faint_bg_color = self.app_background; // striped grid is originally from_additive_luminance(5)
+        style.visuals.code_bg_color = self.ui_element_background;
+        style.visuals.window_fill = self.subtle_background;
+        style.visuals.window_stroke = Stroke::new(1.0, self.subtle_borders_and_separators);
+        style.visuals.panel_fill = self.subtle_background;
+        style.visuals.hyperlink_color = self.hovered_solid_backgrounds;
+        //style.visuals.override_text_color = Some(self.text_color());
     }
 }
 

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -81,7 +81,9 @@ impl ColorTokens {
             ctx.set_visuals_of(egui::Theme::Light, egui::Visuals::light());
         }
 
-        ctx.style_mut(|style| { self.set_egui_style(style); });
+        ctx.style_mut(|style| {
+            self.set_egui_style(style);
+        });
     }
     pub(crate) fn set_local_egui_visuals(&self, ui: &mut Ui) {
         let style = ui.style_mut();

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -85,10 +85,10 @@ impl ColorTokens {
             self.set_egui_style(style);
         });
     }
-    pub(crate) fn set_local_egui_visuals(&self, ui: &mut Ui) {
+    pub(crate) fn set_local_egui_visuals(&self, ui: &mut Ui, dark_mode: bool) {
         let style = ui.style_mut();
 
-        if style.visuals.dark_mode {
+        if dark_mode {
             style.visuals = egui::Visuals::dark();
         } else {
             style.visuals = egui::Visuals::light();


### PR DESCRIPTION
This PR allows applying themes to individual parts of the user interface.

I use it to allow users to style different components in my app differently.

This PR contains some breaking changes:
- Theme editing widgets now take a new `ApplyTo` enum as an argument, which specifies which part of the UI should the theme changes be immediately applied to.
- Calling `Colorix::init` no longer automatically sets the global theme. Users are now expected to call `colorix.apply_global(ctx);` if they want to apply the created theme globally.

---

This was implemented based on my first thoughts, so any suggestions or edits are very welcome.