### PR TITLE
Allow directly setting egui style from tokens

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ impl Colorix {
         colorix.set_colorix_mode(dark_mode);
         colorix.theme = theme;
         colorix.apply_to = ApplyTo::Local;
+        colorix.update_colors(None, None);
         colorix
     }
     #[must_use]

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -139,7 +139,7 @@ impl ColorTokens {
         self.set_egui_style(ui.style_mut());
     }
 
-    fn set_egui_style(&self, style: &mut egui::style::Style) {
+    pub fn set_egui_style(&self, style: &mut egui::style::Style) {
         let shadow = if self.dark_mode {
             Color32::from_black_alpha(96)
         } else {


### PR DESCRIPTION
Exposes `ColorTokens::set_egui_style` to allow directly setting egui's `&mut Style`.

Also fixes the issue when calling `Colorix::local_from_style` resulted in a theme without computed colors until the first call to `update_locally`